### PR TITLE
Fix positionning error of dropdown when using negative margin-top in the document

### DIFF
--- a/tokenize2.js
+++ b/tokenize2.js
@@ -801,11 +801,10 @@
         var $height = this.tokensContainer.outerHeight();
         var $width = this.tokensContainer.outerWidth();
 
+        $position.top += $height;
         this.dropdown.css({
-            top: $position.top + $height,
-            left: $position.left - $(window).scrollLeft(),
             width: $width
-        });
+        }).offset($position);
 
     };
 


### PR DESCRIPTION
Using offset() function to position dropdown instead of css allow to secure positionning (same error occurs when measuring and when positioning, if any)